### PR TITLE
Linking all additional information in one place.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ http://localhost:8070/static/overview.html
 
 * [RDA Recommendation on Research Data Collections (doi: 10.15497/RDA00022)](https://zenodo.org/record/2428145#.XTbIMZMzbbA)
 * [Getting Started & Documentation](https://kit-dm-documentation.readthedocs.io/en/latest/)
+* [API documentation](https://rdacollectionswg.github.io/apidocs/#/)
+* [Interactive tutorial](https://www.katacoda.com/kitdm/scenarios/collection-api)
+* [Docker container](https://hub.docker.com/r/kitdm/collection-api)
+* [HMC website section and flyer](https://helmholtz-metadaten.de/de/fair-data-commons/collection-registry)
 
 ## License
 


### PR DESCRIPTION
This way we can use the link to the heading to easily link to all connected information items at once.

It makes me less look like a spammer when someone asks for material to the implementation :D Some of this information is not available on the HMC website, should we add something there?